### PR TITLE
support bloom

### DIFF
--- a/src/main/java/cn/ussshenzhou/madparticle/particle/ModParticleShaders.java
+++ b/src/main/java/cn/ussshenzhou/madparticle/particle/ModParticleShaders.java
@@ -17,6 +17,7 @@ import net.neoforged.fml.common.Mod;
 @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT, modid = MadParticle.MOD_ID)
 public class ModParticleShaders {
 
+    //instance particle shader
     public static ShaderInstance instancedParticleShader;
     public static final RenderStateShard.ShaderStateShard INSTANCED_SHADER = new RenderStateShard.ShaderStateShard(() -> instancedParticleShader);
 
@@ -38,6 +39,24 @@ public class ModParticleShaders {
         return instancedParticleShaderOitPost;
     }
 
+    //bloom shader
+    public static ShaderInstance downSamplerShader;
+
+    public static ShaderInstance getDownSamplerShader() {
+        return downSamplerShader;
+    }
+
+    public static ShaderInstance bloomCompositeShader;
+
+    public static ShaderInstance getBloomCompositeShader() {
+        return bloomCompositeShader;
+    }
+
+    public static ShaderInstance oitExtractShader;
+
+    public static ShaderInstance getOitExtractShader() {
+        return oitExtractShader;
+    }
 
     @SubscribeEvent
     public static void registerShader(RegisterShadersEvent event) {
@@ -57,6 +76,21 @@ public class ModParticleShaders {
                     new ShaderInstance(resourceManager,
                             ResourceLocation.fromNamespaceAndPath(MadParticle.MOD_ID, "instanced_particle_oit_post"), DefaultVertexFormat.POSITION_TEX),
                     shaderInstance -> instancedParticleShaderOitPost = shaderInstance
+            );
+            event.registerShader(
+                    new ShaderInstance(resourceManager,
+                            ResourceLocation.fromNamespaceAndPath(MadParticle.MOD_ID, "down_sampler"),DefaultVertexFormat.POSITION),
+                            ShaderInstance -> downSamplerShader = ShaderInstance
+            );
+            event.registerShader(
+                    new ShaderInstance(resourceManager,
+                            ResourceLocation.fromNamespaceAndPath(MadParticle.MOD_ID, "bloom_composite"),DefaultVertexFormat.POSITION),
+                    ShaderInstance -> bloomCompositeShader = ShaderInstance
+            );
+            event.registerShader(
+                    new ShaderInstance(resourceManager,
+                            ResourceLocation.fromNamespaceAndPath(MadParticle.MOD_ID, "extract_oit"),DefaultVertexFormat.POSITION),
+                    ShaderInstance -> oitExtractShader = ShaderInstance
             );
         } catch (Exception e) {
             throw new RuntimeException("failed to load particle shader", e);

--- a/src/main/java/cn/ussshenzhou/madparticle/particle/bloom/BloomManager.java
+++ b/src/main/java/cn/ussshenzhou/madparticle/particle/bloom/BloomManager.java
@@ -1,0 +1,291 @@
+package cn.ussshenzhou.madparticle.particle.bloom;
+
+import cn.ussshenzhou.madparticle.particle.ModParticleShaders;
+import com.mojang.blaze3d.pipeline.MainTarget;
+import com.mojang.blaze3d.pipeline.RenderTarget;
+import com.mojang.blaze3d.pipeline.TextureTarget;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.neoforged.fml.loading.FMLLoader;
+import org.lwjgl.opengl.GL46;
+
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+/**
+ * do multi down-sampler, each level will have half width and height than the level before.
+ * do blur at one axis and then another to improve performance.
+ * different levels is similar to the mipmap, but by this way we can use different convolution kernel
+ */
+public class BloomManager implements AutoCloseable {
+
+    public static final boolean DEBUG = !FMLLoader.isProduction();
+    public static final BloomManager INSTANCE = new BloomManager(4);
+
+    private final int downSamplerCount;
+    /**
+     * store data that should go through the bloom pipeline
+     */
+    private final RenderTarget inputTarget;
+    /**
+     * store data that is intended to check a pixel should be bloom or not
+     */
+    private final RenderTarget bloomMaskTarget;
+    /**
+     * we will attach {@link MainTarget#getColorTextureId()} to {@link GL46#GL_COLOR_ATTACHMENT1}
+     * avoid clearing it and remember to re-attach when resized
+     */
+    private final RenderTarget oitOutputTarget;
+    /**
+     * due to openGL don't allow a texture read and write at a single draw call
+     * we draw data to this and then blit it
+     */
+    private final RenderTarget compositeTarget;
+    private final RenderTarget[] downSamplerTexturesHorizon;
+    private final RenderTarget[] downSamplerTexturesVertical;
+
+    /**
+     * MeshData will be closed after upload, so re-create it everytime
+     */
+    private static final Supplier<MeshData> MESH_DATA = () -> {
+        var builder = Tesselator.getInstance()
+                .begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION);
+        builder.addVertex(-1, 1, 0);
+        builder.addVertex(-1, -1, 0);
+        builder.addVertex(1, -1, 0);
+        builder.addVertex(1, 1, 0);
+        return builder.buildOrThrow();
+    };
+
+    /**
+     * Maybe there is a better way to support any down-sampler in composite shader at one time.
+     * currently only support exactly 4
+     */
+    private BloomManager(int downSamplerCount) {
+        this(downSamplerCount, Minecraft.getInstance().getMainRenderTarget());
+    }
+
+    private BloomManager(int downSamplerCount, RenderTarget bloomSizeTarget) {
+        this(downSamplerCount, bloomSizeTarget.width, bloomSizeTarget.height);
+    }
+
+    private BloomManager(int downSamplerCount, int width, int height) {
+        var currentFrameBuffer = GL46.glGetInteger(GL46.GL_FRAMEBUFFER_BINDING);
+        this.downSamplerCount = downSamplerCount <= 0 ? 4 : downSamplerCount;
+        this.inputTarget = createRenderTarget(width, height);
+        this.compositeTarget = createRenderTarget(width, height);
+        this.bloomMaskTarget = createRenderTarget(width, height);
+        this.oitOutputTarget = createRenderTarget(width, height);
+        this.downSamplerTexturesHorizon = IntStream.iterate(2, i -> i * 2)
+                .limit(downSamplerCount)
+                .mapToObj(factor -> createRenderTarget(width / factor, height / factor))
+                .toArray(RenderTarget[]::new);
+        this.downSamplerTexturesVertical = IntStream.iterate(2, i -> i * 2)
+                .limit(downSamplerCount)
+                .mapToObj(factor -> createRenderTarget(width / factor, height / factor))
+                .toArray(RenderTarget[]::new);
+        this.attachMainColorAttachment();
+
+        //these will help you in debug tools
+        if (DEBUG) {
+            GL46.glObjectLabel(GL46.GL_FRAMEBUFFER, inputTarget.frameBufferId, "bloomInput");
+            GL46.glObjectLabel(GL46.GL_FRAMEBUFFER, compositeTarget.frameBufferId, "bloomComposite");
+            GL46.glObjectLabel(GL46.GL_FRAMEBUFFER, bloomMaskTarget.frameBufferId, "bloomMask");
+            GL46.glObjectLabel(GL46.GL_FRAMEBUFFER, oitOutputTarget.frameBufferId, "bloomOitOutput");
+            for (int i = 0; i < downSamplerCount; i++) {
+                RenderTarget samplerTexture = downSamplerTexturesHorizon[i];
+                GL46.glObjectLabel(GL46.GL_FRAMEBUFFER, samplerTexture.frameBufferId,
+                        "bloomProcessHorizon" + (i + 1));
+            }
+            for (int i = 0; i < downSamplerCount; i++) {
+                RenderTarget samplerTexture = downSamplerTexturesVertical[i];
+                GL46.glObjectLabel(GL46.GL_FRAMEBUFFER, samplerTexture.frameBufferId,
+                        "bloomProcessVertical" + (i + 1));
+            }
+        }
+        //state should be recovered
+        GL46.glBindFramebuffer(GL46.GL_FRAMEBUFFER, currentFrameBuffer);
+    }
+
+    private static RenderTarget createRenderTarget(int width, int height) {
+        var renderTarget = new TextureTarget(width, height, false, Minecraft.ON_OSX);
+        renderTarget.setClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+        renderTarget.setFilterMode(GL46.GL_LINEAR);
+        return renderTarget;
+    }
+
+    /**
+     * oit output should also output none-bloom original image,
+     * as we only bloom image data that requires bloom
+     */
+    private void attachMainColorAttachment() {
+        this.oitOutputTarget.bindWrite(false);
+        GL46.glFramebufferTexture2D(GL46.GL_FRAMEBUFFER, GL46.GL_COLOR_ATTACHMENT1, GL46.GL_TEXTURE_2D,
+                Minecraft.getInstance().getMainRenderTarget().getColorTextureId(), 0);
+        GL46.glDrawBuffers(new int[]{GL46.GL_COLOR_ATTACHMENT0, GL46.GL_COLOR_ATTACHMENT1});
+    }
+
+    public void resize(int newWidth, int newHeight) {
+        this.inputTarget.resize(newWidth, newHeight, Minecraft.ON_OSX);
+        this.compositeTarget.resize(newWidth, newHeight, Minecraft.ON_OSX);
+        this.bloomMaskTarget.resize(newWidth, newHeight, Minecraft.ON_OSX);
+        this.oitOutputTarget.resize(newWidth, newHeight, Minecraft.ON_OSX);
+        IntStream.range(0, downSamplerCount).forEach(i -> {
+            var factor = (int) Math.pow(2, i);
+            this.downSamplerTexturesHorizon[i].resize(newWidth / factor, newHeight / factor, Minecraft.ON_OSX);
+            this.downSamplerTexturesVertical[i].resize(newWidth / factor, newHeight / factor, Minecraft.ON_OSX);
+        });
+        //need re-attach, after resize colorAttachment(texture)'is will change
+        this.attachMainColorAttachment();
+    }
+
+    public RenderTarget getInputTarget() {
+        return this.inputTarget;
+    }
+
+    public RenderTarget getBloomMaskTarget() {
+        return this.bloomMaskTarget;
+    }
+
+    public RenderTarget getOitOutputTarget() {
+        return this.oitOutputTarget;
+    }
+
+    public void doBloom() {
+        //assume the needed bloom information is all in inputTarget
+        var downSamplerShader = ModParticleShaders.getDownSamplerShader();
+        //process bloom
+        for (int i = 0; i < this.downSamplerCount; i++) {
+            var sourceRenderTarget = i == 0 ? this.inputTarget : this.downSamplerTexturesHorizon[i - 1];
+            var targetRenderTarget = this.downSamplerTexturesHorizon[i];
+
+            float outWidth = (float) targetRenderTarget.width;
+            float outHeight = (float) targetRenderTarget.height;
+
+            targetRenderTarget.bindWrite(true);
+            GL46.glClear(GL46.GL_COLOR_BUFFER_BIT);
+
+            downSamplerShader.setSampler("DiffuseSampler", sourceRenderTarget.getColorTextureId());
+            downSamplerShader.safeGetUniform("OutSize")
+                    .set(outWidth, outHeight);
+            downSamplerShader.safeGetUniform("BlurDir")
+                    .set(1.0f, 0.0f);
+            downSamplerShader.safeGetUniform("Radius").
+                    set((i + 1) * 7 + 1);
+
+            RenderSystem.setShader(ModParticleShaders::getDownSamplerShader);
+            BufferUploader.drawWithShader(MESH_DATA.get());
+
+            sourceRenderTarget = targetRenderTarget;
+            targetRenderTarget = this.downSamplerTexturesVertical[i];
+
+            targetRenderTarget.bindWrite(true);
+            GL46.glClear(GL46.GL_COLOR_BUFFER_BIT);
+            downSamplerShader.setSampler("DiffuseSampler", sourceRenderTarget.getColorTextureId());
+            downSamplerShader.safeGetUniform("BlurDir")
+                    .set(0.0f, 1.0f);
+            BufferUploader.drawWithShader(MESH_DATA.get());
+        }
+
+        //do composite
+        var compositeShader = ModParticleShaders.getBloomCompositeShader();
+        this.setupBloomTexturesForComposite(compositeShader);
+        compositeShader.setSampler("DiffuseSampler", Minecraft.getInstance().getMainRenderTarget().getColorTextureId());
+        compositeShader.setSampler("HighLight", inputTarget.getColorTextureId());
+
+        compositeShader.safeGetUniform("BloomRadius").set(1.0f);
+        compositeShader.safeGetUniform("BloomIntensive").set(1.7f);
+
+        compositeTarget.bindWrite(true);
+        GL46.glClear(GL46.GL_COLOR_BUFFER_BIT);
+
+        RenderSystem.setShader(ModParticleShaders::getBloomCompositeShader);
+        BufferUploader.drawWithShader(MESH_DATA.get());
+        this.shutdownBloomTexturesForComposite(compositeShader);
+
+        //do blit
+        GL46.glBindFramebuffer(GL46.GL_READ_FRAMEBUFFER, compositeTarget.frameBufferId);
+        GL46.glBindFramebuffer(GL46.GL_DRAW_FRAMEBUFFER, Minecraft.getInstance().getMainRenderTarget().frameBufferId);
+        var width = compositeTarget.width;
+        var height = compositeTarget.height;
+        GL46.glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                GL46.GL_COLOR_BUFFER_BIT, GL46.GL_LINEAR);
+    }
+
+    /**
+     * {@link GL46#GL_TEXTURE_2D_ARRAY} requires all textures at same size, can't use it here
+     **/
+    private void setupBloomTexturesForComposite(ShaderInstance compositeShader) {
+        GL46.glUseProgram(compositeShader.getId());
+        var index = compositeShader.samplerLocations.size() + 1;
+        var activeTexture = GL46.glGetInteger(GL46.GL_ACTIVE_TEXTURE);
+        for (int i = 0; i < this.downSamplerTexturesHorizon.length; i++) {
+            var location = GL46.glGetUniformLocation(compositeShader.getId(), "BlurTexture" + (i + 1));
+            GL46.glUniform1i(location, index + i);
+            GL46.glActiveTexture(GL46.GL_TEXTURE0 + index + i);
+            GL46.glBindTexture(GL46.GL_TEXTURE_2D, this.downSamplerTexturesVertical[i].getColorTextureId());
+        }
+        GL46.glActiveTexture(activeTexture);
+    }
+
+    private void shutdownBloomTexturesForComposite(ShaderInstance compositeShader) {
+        var index = compositeShader.samplerLocations.size() + 1;
+        var activeTexture = GL46.glGetInteger(GL46.GL_ACTIVE_TEXTURE);
+        for (int i = 0; i < this.downSamplerTexturesHorizon.length; i++) {
+            GL46.glActiveTexture(GL46.GL_TEXTURE0 + index + i);
+            GL46.glBindTexture(GL46.GL_TEXTURE_2D, 0);
+        }
+        GL46.glActiveTexture(activeTexture);
+    }
+
+    @Override
+    public void close() {
+        this.inputTarget.destroyBuffers();
+        this.compositeTarget.destroyBuffers();
+        this.bloomMaskTarget.destroyBuffers();
+        for (var downSamplerTexture : this.downSamplerTexturesHorizon) {
+            downSamplerTexture.destroyBuffers();
+        }
+        for (var downSamplerTexture : this.downSamplerTexturesVertical) {
+            downSamplerTexture.destroyBuffers();
+        }
+    }
+
+    /**
+     * assume candidate Bloom information in {@link  BloomManager#oitOutputTarget}
+     * assume bloom stencil data stored in {@link  BloomManager#bloomMaskTarget}
+     */
+    public void extractOIT() {
+        var oitExtractShader = ModParticleShaders.getOitExtractShader();
+        oitExtractShader.setSampler("BloomMask", this.bloomMaskTarget.getColorTextureId());
+        oitExtractShader.setSampler("OitOutput", this.oitOutputTarget.getColorTextureId());
+
+        this.inputTarget.bindWrite(true);
+        GL46.glClear(GL46.GL_COLOR_BUFFER_BIT);
+
+        RenderSystem.setShader(ModParticleShaders::getOitExtractShader);
+        BufferUploader.drawWithShader(MESH_DATA.get());
+
+        this.bloomMaskTarget.bindWrite(true);
+        GL46.glClear(GL46.GL_COLOR_BUFFER_BIT);
+    }
+
+    /**
+     * when fill vertex data, we should let extraLight/bloomFactor greater than 1,
+     * in shader now, greater than 1.001f
+     */
+    public boolean isBloomOn() {
+        return true;
+    }
+
+    /**
+     * @param colorAttachment like {@link GL46#GL_COLOR_ATTACHMENT2}
+     */
+    public void attachBloomMaskTargetToOit(int colorAttachment) {
+        int textureId = this.getBloomMaskTarget().getColorTextureId();
+        GL46.glFramebufferTexture2D(GL46.GL_FRAMEBUFFER, colorAttachment,
+                GL46.GL_TEXTURE_2D, textureId, 0);
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -60,4 +60,4 @@ public com.mojang.blaze3d.vertex.VertexFormatElement ELEMENTS # ELEMENTS
 public net.minecraft.client.particle.Particle removed # removed
 public net.minecraft.client.renderer.texture.TextureAtlasSprite *
 public net.minecraft.world.phys.shapes.IndexMerger
-
+public net.minecraft.client.renderer.ShaderInstance samplerLocations # samplerLocations

--- a/src/main/resources/assets/madparticle/shaders/core/blit.vsh
+++ b/src/main/resources/assets/madparticle/shaders/core/blit.vsh
@@ -1,0 +1,9 @@
+#version 150
+
+in vec3 Position;
+out vec2 texCoord;
+
+void main() {
+    gl_Position = vec4(Position.x, Position.y, 0, 1.0);
+    texCoord = Position.xy * 0.5 + 0.5;
+}

--- a/src/main/resources/assets/madparticle/shaders/core/bloom_composite.fsh
+++ b/src/main/resources/assets/madparticle/shaders/core/bloom_composite.fsh
@@ -1,0 +1,37 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform sampler2D HighLight;
+uniform sampler2D BlurTexture1;
+uniform sampler2D BlurTexture2;
+uniform sampler2D BlurTexture3;
+uniform sampler2D BlurTexture4;
+uniform float BloomRadius;
+uniform float BloomIntensive;
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+float lerpBloomFactor(const in float factor) {
+    float mirrorFactor = 1.2 - factor;
+    return mix(factor, mirrorFactor, BloomRadius);
+}
+
+vec3 jodieReinhardTonemap(vec3 c) {
+    float l = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    vec3 tc = c / (c + 1.0);
+
+    return mix(c / (l + 1.0), tc, tc);
+}
+
+void main() {
+    vec4 bloom = BloomIntensive * (lerpBloomFactor(1.) * texture(BlurTexture1, texCoord) +
+        lerpBloomFactor(0.8) * texture(BlurTexture2, texCoord) +
+        lerpBloomFactor(0.6) * texture(BlurTexture3, texCoord) +
+        lerpBloomFactor(0.4) * texture(BlurTexture4, texCoord));
+
+    vec4 background = texture(DiffuseSampler, texCoord);
+    vec4 highLight = texture(HighLight, texCoord);
+    background.rgb = background.rgb * (1 - highLight.a) + highLight.a * highLight.rgb;
+    fragColor = vec4(background.rgb + jodieReinhardTonemap(bloom.rgb), 1.);
+}

--- a/src/main/resources/assets/madparticle/shaders/core/bloom_composite.json
+++ b/src/main/resources/assets/madparticle/shaders/core/bloom_composite.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "one",
+    "dstrgb": "zero"
+  },
+  "vertex": "madparticle:blit",
+  "fragment": "madparticle:bloom_composite",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" },
+    { "name": "HighLight" }
+  ],
+  "uniforms": [
+    { "name": "BloomRadius",      "type": "float",     "count": 1,  "values": [ 1.0 ] },
+    { "name": "BloomIntensive",      "type": "float",     "count": 1,  "values": [ 1.7 ] }
+  ]
+}

--- a/src/main/resources/assets/madparticle/shaders/core/down_sampler.fsh
+++ b/src/main/resources/assets/madparticle/shaders/core/down_sampler.fsh
@@ -1,0 +1,30 @@
+#version 150
+
+uniform sampler2D DiffuseSampler;
+uniform vec2 OutSize;
+uniform vec2 BlurDir;
+uniform int Radius;
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+float gaussianPdf(in float x, in float sigma) {
+    return 0.39894 * exp( -0.5 * x * x/( sigma * sigma))/sigma;
+}
+
+void main(){
+    vec2 invSize = 1.0 / OutSize;
+    float fSigma = float(Radius);
+    float weightSum = gaussianPdf(0.0, fSigma);
+    vec3 diffuseSum = texture(DiffuseSampler, texCoord).rgb * weightSum;
+    for( int i = 1; i < Radius; i ++) {
+        float x = float(i);
+        float w = gaussianPdf(x, fSigma);
+        vec2 uvOffset = BlurDir * invSize * x;
+        vec3 sample1 = texture(DiffuseSampler, texCoord + uvOffset).rgb;
+        vec3 sample2 = texture(DiffuseSampler, texCoord - uvOffset).rgb;
+        diffuseSum += (sample1 + sample2) * w;
+        weightSum += 2.0 * w;
+    }
+    fragColor = vec4(diffuseSum/weightSum, 1.0);
+}

--- a/src/main/resources/assets/madparticle/shaders/core/down_sampler.json
+++ b/src/main/resources/assets/madparticle/shaders/core/down_sampler.json
@@ -1,0 +1,18 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "one",
+    "dstrgb": "zero"
+  },
+  "vertex": "madparticle:blit",
+  "fragment": "madparticle:down_sampler",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "DiffuseSampler" }
+  ],
+  "uniforms": [
+    { "name": "OutSize",     "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+    { "name": "BlurDir",     "type": "float",     "count": 2,  "values": [ 0.0, 0.0 ] },
+    { "name": "Radius",      "type": "int",     "count": 1,  "values": [ 5 ] }
+  ]
+}

--- a/src/main/resources/assets/madparticle/shaders/core/extract_oit.fsh
+++ b/src/main/resources/assets/madparticle/shaders/core/extract_oit.fsh
@@ -1,0 +1,13 @@
+#version 150
+
+uniform sampler2D OitOutput;
+uniform sampler2D BloomMask;
+
+in vec2 texCoord;
+out vec4 bloomColor;
+
+void main() {
+    vec4 marker = texture(BloomMask, texCoord);
+    vec4 oitOutput = texture(OitOutput, texCoord);
+    bloomColor = oitOutput * marker;
+}

--- a/src/main/resources/assets/madparticle/shaders/core/extract_oit.json
+++ b/src/main/resources/assets/madparticle/shaders/core/extract_oit.json
@@ -1,0 +1,16 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "one",
+    "dstrgb": "zero"
+  },
+  "vertex": "madparticle:blit",
+  "fragment": "madparticle:extract_oit",
+  "attributes": [ "Position" ],
+  "samplers": [
+    { "name": "OitOutput" },
+    { "name": "BloomMask" }
+  ],
+  "uniforms": [
+  ]
+}

--- a/src/main/resources/assets/madparticle/shaders/core/instanced_particle.fsh
+++ b/src/main/resources/assets/madparticle/shaders/core/instanced_particle.fsh
@@ -12,8 +12,10 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec2 texCoord0;
 in vec4 vertexColor;
+in float bloomConditionLight;
 
 out vec4 fragColor;
+out vec4 bloomColor;
 
 void main() {
     vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
@@ -21,4 +23,7 @@ void main() {
         discard;
     }
     fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+    if (bloomConditionLight > 1.001f) {
+        bloomColor = fragColor;
+    }
 }

--- a/src/main/resources/assets/madparticle/shaders/core/instanced_particle.vsh
+++ b/src/main/resources/assets/madparticle/shaders/core/instanced_particle.vsh
@@ -24,6 +24,7 @@ uniform vec4 CamQuat;
 out float vertexDistance;
 out vec2 texCoord0;
 out vec4 vertexColor;
+out float bloomConditionLight;
 
 const vec4 UV_CONTROL[4] = vec4[4](
 vec4(0, 1, 0, 1),
@@ -65,6 +66,7 @@ void main() {
     texCoord0 = vec2(dot(instanceUV.xy, uvControl.xy), dot(instanceUV.zw, uvControl.zw));
     ivec2 uv2 = ivec2(instanceUV2 & 0xfu, (instanceUV2 >> 4) & 0xfu);
     vertexColor = vec4(instanceColor.xyz * sizeExtraLight.y, instanceColor.w) * texelFetch(Sampler2, uv2, 0);
+    bloomConditionLight = sizeExtraLight.y;
 }
 
 mat4 rotate(vec4 quat, mat4 matrix) {

--- a/src/main/resources/assets/madparticle/shaders/core/instanced_particle_oit.fsh
+++ b/src/main/resources/assets/madparticle/shaders/core/instanced_particle_oit.fsh
@@ -12,9 +12,11 @@ uniform vec4 FogColor;
 in float vertexDistance;
 in vec2 texCoord0;
 in vec4 vertexColor;
+in float bloomConditionLight;
 
 out vec4 accum;
 out float reveal;
+out vec4 bloomColor;
 
 void main() {
     vec4 color = linear_fog(texture(Sampler0, texCoord0) * vertexColor * ColorModulator, vertexDistance, FogStart, FogEnd, FogColor);
@@ -37,4 +39,9 @@ void main() {
     );
     accum = vec4(color.rgb * color.a, color.a) * weight;
     reveal = color.a;
+    if(bloomConditionLight > 1.001f) {
+        bloomColor = vec4(1.0);
+    }else{
+        bloomColor = vec4(0.0);
+    }
 }


### PR DESCRIPTION
# Summerize
this pull request supports particles which is an instance of MadParticle to be bloomed, but this is 
not important. This pr mainly introduced a pipeline that does bloom and merges bloom results into the origin image. You can bloom anything by the pipeline, just making a proper change.
![bloom](https://github.com/user-attachments/assets/28c9fd1f-696a-439a-8d12-025cba13237b)

# Imporat things
```java
//size extraLight
MemoryUtil.memPutFloat(start + 32, particle.getQuadSize(partialTicks));
if ((irisOn || BloomManager.INSTANCE.isBloomOn()) && particle instanceof MadParticle madParticle) {
    MemoryUtil.memPutFloat(start + 36, madParticle.getBloomFactor());
    } else {
    MemoryUtil.memPutFloat(start + 36, 1.0f);
}
```
currently, extra light's second component will also be set
and when it is greater than 1.001f(hardcode in the shader), we consider it should participate in the bloom pipeline.
Most bloom related stuffs are located in `BloomManager` with detailed comments, see them if you need

# Note

this pr only supports the instance OIT pipeline, others are not yet supported.
works under sodium and other things that need future tests.

If you have seen code in [shimmer](https://github.com/Low-Drag-MC/Shimmer), you may find that the shader code is similar, that is true. So if this pr was merged, you could add mention to that project in a way you like.

If you need more help, contact me recently. I may be busy soon.